### PR TITLE
Validate SQL queries to Prevent Postgres Function Calls

### DIFF
--- a/src/mastra/tools/sql-execution-tool.ts
+++ b/src/mastra/tools/sql-execution-tool.ts
@@ -44,6 +44,7 @@ const validateQuery = (query: string) => {
     /\bload_file\b/i,      // File loading
     /\beval\b/i,           // Code evaluation
     /\bexecute\b/i,        // Dynamic execution
+    /\bsleep\b/i,          // Sleep execution
   ];
 
   for (const pattern of dangerousPatterns) {
@@ -52,7 +53,7 @@ const validateQuery = (query: string) => {
     }
   }
 
-  // Check function calls against whitelist
+  // Check function calls against allow list
   const functionMatches = trimmedQuery.match(/\b(\w+)\s*\(/g);
   if (functionMatches) {
     for (const match of functionMatches) {

--- a/src/mastra/tools/sql-execution-tool.ts
+++ b/src/mastra/tools/sql-execution-tool.ts
@@ -22,6 +22,48 @@ const executeQuery = async (client: Client, query: string) => {
   }
 };
 
+const ALLOWED_FUNCTIONS = new Set([
+  'count', 'sum', 'avg', 'min', 'max',
+  'upper', 'lower', 'length', 'substring',
+  'date_part', 'now', 'current_timestamp', 'current_date',
+  'coalesce', 'greatest', 'least'
+]);
+
+const validateQuery = (query: string) => {
+  const trimmedQuery = query.trim().toLowerCase();
+
+  if (!trimmedQuery.startsWith('select')) {
+    throw new Error('Only SELECT queries are allowed for security reasons');
+  }
+
+  // Block common dangerous patterns
+  const dangerousPatterns = [
+    /pg_\w+\(/i,           // PostgreSQL system functions
+    /\bcopy\b/i,           // COPY command
+    /\binto\s+outfile/i,   // File operations
+    /\bload_file\b/i,      // File loading
+    /\beval\b/i,           // Code evaluation
+    /\bexecute\b/i,        // Dynamic execution
+  ];
+
+  for (const pattern of dangerousPatterns) {
+    if (pattern.test(trimmedQuery)) {
+      throw new Error('Query contains potentially dangerous operations');
+    }
+  }
+
+  // Check function calls against whitelist
+  const functionMatches = trimmedQuery.match(/\b(\w+)\s*\(/g);
+  if (functionMatches) {
+    for (const match of functionMatches) {
+      const functionName = match.replace(/\s*\(/, '').toLowerCase();
+      if (!ALLOWED_FUNCTIONS.has(functionName)) {
+        throw new Error(`Function '${functionName}' is not allowed for security reasons`);
+      }
+    }
+  }
+};
+
 export const sqlExecutionTool = createTool({
   id: 'sql-execution',
   inputSchema: z.object({
@@ -33,31 +75,29 @@ export const sqlExecutionTool = createTool({
     const client = createDatabaseConnection(connectionString);
 
     try {
-      console.log('🔌 Connecting to PostgreSQL for query execution...');
-      await client.connect();
-      console.log('✅ Connected to PostgreSQL for query execution');
+        console.log('🔌 Connecting to PostgreSQL for query execution...');
+        await client.connect();
+        console.log('✅ Connected to PostgreSQL for query execution');
 
-      const trimmedQuery = query.trim().toLowerCase();
-      if (!trimmedQuery.startsWith('select')) {
-        throw new Error('Only SELECT queries are allowed for security reasons');
-      }
+        // Enhanced validation
+        validateQuery(query);
 
-      const result = await executeQuery(client, query);
+        const result = await executeQuery(client, query);
 
-      return {
-        success: true,
-        data: result,
-        rowCount: result.length,
-        executedQuery: query,
-      };
+        return {
+            success: true,
+            data: result,
+            rowCount: result.length,
+            executedQuery: query,
+        };
     } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : String(error),
-        executedQuery: query,
-      };
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+            executedQuery: query,
+        };
     } finally {
-      await client.end();
+        await client.end();
     }
   },
 });


### PR DESCRIPTION
In the sqlExecutionTool call we validate that we only allow SELECT statements but this still allows internal postgres functions to be called. 

These can be dangerous such as when pg_sleep is called and creates long running queries that could result in a denial of service. 

This PR adds validation around which function calls are allowed as defined by an allow list.